### PR TITLE
Feature/#9 코드 리뷰 반영

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -1,12 +1,10 @@
 import { useLocalStorage } from "usehooks-ts";
-
 import { Card, CardContent, CardHeader, CardTitle } from "@/components/ui/card";
-
 import MedalForm from "@/containers/MedalForm";
 import MedalTable from "@/containers/MedalTable";
+import { LOCAL_STORAGE_MEDAL_LIST } from "@/constants";
 
 import { MedalRecordDto } from "@/types.dto";
-import { LOCAL_STORAGE_MEDAL_LIST } from "./constants";
 
 function App() {
   const [medalList, setMedalList] = useLocalStorage<MedalRecordDto[]>(

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -6,10 +6,8 @@ import { Card, CardContent, CardHeader, CardTitle } from "@/components/ui/card";
 import MedalForm from "@/containers/MedalForm";
 import MedalTable from "@/containers/MedalTable";
 
-import { MEDAL_FORM_SUBMIT_TYPE } from "@/types.type";
+import { MEDAL_FORM_SUBMIT_TYPE, MEDAL_TYPE } from "@/types.type";
 import { MedalRecordDto } from "@/types.dto";
-
-import { MEDAL_TYPES } from "@/constants/medal.constant";
 
 function App() {
   const [medalList, setMedalList] = useLocalStorage<MedalRecordDto[]>(
@@ -47,7 +45,9 @@ function App() {
         <MedalTable
           medalList={medalList.map((item) => ({
             ...item,
-            total: MEDAL_TYPES.reduce((acc, value) => acc + item[value], 0),
+            total: (
+              Object.keys(MEDAL_TYPE) as Array<keyof typeof MEDAL_TYPE>
+            ).reduce((sum, key) => sum + item[MEDAL_TYPE[key]], 0),
           }))}
           setMedalList={setMedalList}
         />

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -15,7 +15,7 @@ function App() {
   );
 
   return (
-    <Card className="min-w-[600px] max-w-[1000px] w-4/5 mx-auto mt-12">
+    <Card className="min-w-[37.5rem] max-w-[62.5rem] w-4/5 mx-auto mt-12">
       <CardHeader>
         <CardTitle>2024 파리 올림픽</CardTitle>
       </CardHeader>

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -7,7 +7,7 @@ import MedalForm from "@/containers/MedalForm";
 import MedalTable from "@/containers/MedalTable";
 
 import { MEDAL_FORM_SUBMIT_TYPE, MEDAL_TYPE } from "@/types.type";
-import { MedalRecordDto } from "@/types.dto";
+import { MedalDataDto, MedalRecordDto } from "@/types.dto";
 
 function App() {
   const [medalList, setMedalList] = useLocalStorage<MedalRecordDto[]>(
@@ -15,10 +15,7 @@ function App() {
     []
   );
 
-  function handleSubmit(
-    formData: MedalRecordDto,
-    type: MEDAL_FORM_SUBMIT_TYPE
-  ) {
+  function handleSubmit(formData: MedalDataDto, type: MEDAL_FORM_SUBMIT_TYPE) {
     if (MedalFormSubmitConfig[type].isInvalidate(medalList, formData.country)) {
       toast.warning("잘못된 입력 방식입니다.", {
         description: MedalFormSubmitConfig[type].errorMessage,
@@ -26,12 +23,20 @@ function App() {
       return;
     }
 
+    const id = crypto.randomUUID();
+    const totalMedalCount = (
+      Object.keys(MEDAL_TYPE) as Array<keyof typeof MEDAL_TYPE>
+    ).reduce((sum, key) => sum + formData[MEDAL_TYPE[key]], 0);
+
     if (type === MEDAL_FORM_SUBMIT_TYPE.ADD)
-      setMedalList((prev) => [...prev, formData]);
+      setMedalList((prev) => [
+        ...prev,
+        { ...formData, id, total: totalMedalCount },
+      ]);
     if (type === MEDAL_FORM_SUBMIT_TYPE.UPDATE)
       setMedalList((prev) => [
         ...prev.filter((item) => item.country !== formData.country),
-        formData,
+        { ...formData, id, total: totalMedalCount },
       ]);
   }
 
@@ -61,7 +66,7 @@ export default App;
 const MedalFormSubmitConfig: {
   [key in MEDAL_FORM_SUBMIT_TYPE]: {
     errorMessage: string;
-    isInvalidate: (list: MedalRecordDto[], country: string) => boolean;
+    isInvalidate: (list: MedalDataDto[], country: string) => boolean;
   };
 } = {
   [MEDAL_FORM_SUBMIT_TYPE.ADD]: {

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -1,4 +1,3 @@
-import { toast } from "sonner";
 import { useLocalStorage } from "usehooks-ts";
 
 import { Card, CardContent, CardHeader, CardTitle } from "@/components/ui/card";
@@ -6,39 +5,14 @@ import { Card, CardContent, CardHeader, CardTitle } from "@/components/ui/card";
 import MedalForm from "@/containers/MedalForm";
 import MedalTable from "@/containers/MedalTable";
 
-import { MEDAL_FORM_SUBMIT_TYPE, MEDAL_TYPE } from "@/types.type";
-import { MedalDataDto, MedalRecordDto } from "@/types.dto";
+import { MedalRecordDto } from "@/types.dto";
+import { LOCAL_STORAGE_MEDAL_LIST } from "./constants";
 
 function App() {
   const [medalList, setMedalList] = useLocalStorage<MedalRecordDto[]>(
-    "medal-list",
+    LOCAL_STORAGE_MEDAL_LIST,
     []
   );
-
-  function handleSubmit(formData: MedalDataDto, type: MEDAL_FORM_SUBMIT_TYPE) {
-    if (MedalFormSubmitConfig[type].isInvalidate(medalList, formData.country)) {
-      toast.warning("잘못된 입력 방식입니다.", {
-        description: MedalFormSubmitConfig[type].errorMessage,
-      });
-      return;
-    }
-
-    const id = crypto.randomUUID();
-    const totalMedalCount = (
-      Object.keys(MEDAL_TYPE) as Array<keyof typeof MEDAL_TYPE>
-    ).reduce((sum, key) => sum + formData[MEDAL_TYPE[key]], 0);
-
-    if (type === MEDAL_FORM_SUBMIT_TYPE.ADD)
-      setMedalList((prev) => [
-        ...prev,
-        { ...formData, id, total: totalMedalCount },
-      ]);
-    if (type === MEDAL_FORM_SUBMIT_TYPE.UPDATE)
-      setMedalList((prev) => [
-        ...prev.filter((item) => item.country !== formData.country),
-        { ...formData, id, total: totalMedalCount },
-      ]);
-  }
 
   return (
     <Card className="min-w-[600px] max-w-[1000px] w-4/5 mx-auto mt-12">
@@ -46,37 +20,11 @@ function App() {
         <CardTitle>2024 파리 올림픽</CardTitle>
       </CardHeader>
       <CardContent className="flex flex-col gap-5">
-        <MedalForm onSubmit={handleSubmit} />
-        <MedalTable
-          medalList={medalList.map((item) => ({
-            ...item,
-            total: (
-              Object.keys(MEDAL_TYPE) as Array<keyof typeof MEDAL_TYPE>
-            ).reduce((sum, key) => sum + item[MEDAL_TYPE[key]], 0),
-          }))}
-          setMedalList={setMedalList}
-        />
+        <MedalForm setMedalList={setMedalList} />
+        <MedalTable medalList={medalList} setMedalList={setMedalList} />
       </CardContent>
     </Card>
   );
 }
 
 export default App;
-
-const MedalFormSubmitConfig: {
-  [key in MEDAL_FORM_SUBMIT_TYPE]: {
-    errorMessage: string;
-    isInvalidate: (list: MedalDataDto[], country: string) => boolean;
-  };
-} = {
-  [MEDAL_FORM_SUBMIT_TYPE.ADD]: {
-    errorMessage: "이미 존재하는 국가입니다.",
-    isInvalidate: (list, country) =>
-      list.some((item) => item.country === country),
-  },
-  [MEDAL_FORM_SUBMIT_TYPE.UPDATE]: {
-    errorMessage: "기존에 존재하지 않은 국가입니다.",
-    isInvalidate: (list, country) =>
-      !list.some((item) => item.country === country),
-  },
-};

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -6,7 +6,7 @@ import { Card, CardContent, CardHeader, CardTitle } from "@/components/ui/card";
 import MedalForm from "@/containers/MedalForm";
 import MedalTable from "@/containers/MedalTable";
 
-import { MedalFormSubmitType } from "@/types.type";
+import { MEDAL_FORM_SUBMIT_TYPE } from "@/types.type";
 import { MedalRecordDto } from "@/types.dto";
 
 import { MEDAL_TYPES } from "@/constants/medal.constant";
@@ -17,7 +17,10 @@ function App() {
     []
   );
 
-  function handleSubmit(formData: MedalRecordDto, type: MedalFormSubmitType) {
+  function handleSubmit(
+    formData: MedalRecordDto,
+    type: MEDAL_FORM_SUBMIT_TYPE
+  ) {
     if (MedalFormSubmitConfig[type].isInvalidate(medalList, formData.country)) {
       toast.warning("잘못된 입력 방식입니다.", {
         description: MedalFormSubmitConfig[type].errorMessage,
@@ -25,9 +28,9 @@ function App() {
       return;
     }
 
-    if (type === MedalFormSubmitType.ADD)
+    if (type === MEDAL_FORM_SUBMIT_TYPE.ADD)
       setMedalList((prev) => [...prev, formData]);
-    if (type === MedalFormSubmitType.UPDATE)
+    if (type === MEDAL_FORM_SUBMIT_TYPE.UPDATE)
       setMedalList((prev) => [
         ...prev.filter((item) => item.country !== formData.country),
         formData,
@@ -56,17 +59,17 @@ function App() {
 export default App;
 
 const MedalFormSubmitConfig: {
-  [key in MedalFormSubmitType]: {
+  [key in MEDAL_FORM_SUBMIT_TYPE]: {
     errorMessage: string;
     isInvalidate: (list: MedalRecordDto[], country: string) => boolean;
   };
 } = {
-  [MedalFormSubmitType.ADD]: {
+  [MEDAL_FORM_SUBMIT_TYPE.ADD]: {
     errorMessage: "이미 존재하는 국가입니다.",
     isInvalidate: (list, country) =>
       list.some((item) => item.country === country),
   },
-  [MedalFormSubmitType.UPDATE]: {
+  [MEDAL_FORM_SUBMIT_TYPE.UPDATE]: {
     errorMessage: "기존에 존재하지 않은 국가입니다.",
     isInvalidate: (list, country) =>
       !list.some((item) => item.country === country),

--- a/src/constants.ts
+++ b/src/constants.ts
@@ -1,3 +1,5 @@
+export const LOCAL_STORAGE_MEDAL_LIST = "medal-list";
+
 export const PARIS_OLYMPICS_COUNTRIES: string[] = [
   "가나",
   "가봉",

--- a/src/constants/medal.constant.ts
+++ b/src/constants/medal.constant.ts
@@ -1,8 +1,0 @@
-export const MEDAL_TYPES = ["gold", "sliver", "bronze"] as const;
-export type MedalType = (typeof MEDAL_TYPES)[number];
-
-export const MEDAL_LABELS: Record<MedalType, string> = {
-  gold: "금메달",
-  sliver: "은메달",
-  bronze: "동메달",
-};

--- a/src/containers/MedalForm.tsx
+++ b/src/containers/MedalForm.tsx
@@ -6,15 +6,15 @@ import { Button } from "@/components/ui/button";
 import { Combobox } from "@/components/ui/combobox";
 
 import { PARIS_OLYMPICS_COUNTRIES_OPTION } from "@/constants/country.constant";
-import { MedalRecordDto } from "@/types.dto";
+import { MedalDataDto } from "@/types.dto";
 import { MEDAL_FORM_SUBMIT_TYPE, MEDAL_LABELS, MEDAL_TYPE } from "@/types.type";
 
 export interface MedalFormProps {
-  onSubmit: (data: MedalRecordDto, type: MEDAL_FORM_SUBMIT_TYPE) => void;
+  onSubmit: (data: MedalDataDto, type: MEDAL_FORM_SUBMIT_TYPE) => void;
 }
 
 export default function MedalForm({ onSubmit }: MedalFormProps) {
-  const [formData, setFormData] = useState<MedalRecordDto>(initialFormData);
+  const [formData, setFormData] = useState<MedalDataDto>(initialFormData);
 
   function handleCountryChange(newCountry: string) {
     setFormData((prev) => ({
@@ -90,14 +90,14 @@ export default function MedalForm({ onSubmit }: MedalFormProps) {
   );
 }
 
-const initialFormData: MedalRecordDto = {
+const initialFormData: MedalDataDto = {
   country: "",
   gold: 0,
   sliver: 0,
   bronze: 0,
 };
 
-function isInvalidateMedalFormData(formData: MedalRecordDto) {
+function isInvalidateMedalFormData(formData: MedalDataDto) {
   if (formData.country === "") return true;
   if (formData.gold < 0 || formData.sliver < 0 || formData.bronze < 0)
     return true;

--- a/src/containers/MedalForm.tsx
+++ b/src/containers/MedalForm.tsx
@@ -8,10 +8,10 @@ import { Combobox } from "@/components/ui/combobox";
 import { MEDAL_LABELS, MEDAL_TYPES } from "@/constants/medal.constant";
 import { PARIS_OLYMPICS_COUNTRIES_OPTION } from "@/constants/country.constant";
 import { MedalRecordDto } from "@/types.dto";
-import { MedalFormSubmitType } from "@/types.type";
+import { MEDAL_FORM_SUBMIT_TYPE } from "@/types.type";
 
 export interface MedalFormProps {
-  onSubmit: (data: MedalRecordDto, type: MedalFormSubmitType) => void;
+  onSubmit: (data: MedalRecordDto, type: MEDAL_FORM_SUBMIT_TYPE) => void;
 }
 
 export default function MedalForm({ onSubmit }: MedalFormProps) {
@@ -45,7 +45,7 @@ export default function MedalForm({ onSubmit }: MedalFormProps) {
       .submitter as HTMLButtonElement;
     const action = submitter.formAction.split("/").at(-1);
 
-    onSubmit(formData, action as MedalFormSubmitType);
+    onSubmit(formData, action as MEDAL_FORM_SUBMIT_TYPE);
     setFormData(initialFormData);
   }
 
@@ -77,11 +77,11 @@ export default function MedalForm({ onSubmit }: MedalFormProps) {
         <Button
           variant="outline"
           type="submit"
-          formAction={MedalFormSubmitType.UPDATE.toString()}
+          formAction={MEDAL_FORM_SUBMIT_TYPE.UPDATE}
         >
           갱신하기
         </Button>
-        <Button type="submit" formAction={MedalFormSubmitType.ADD.toString()}>
+        <Button type="submit" formAction={MEDAL_FORM_SUBMIT_TYPE.ADD}>
           추가하기
         </Button>
       </div>

--- a/src/containers/MedalForm.tsx
+++ b/src/containers/MedalForm.tsx
@@ -1,17 +1,16 @@
 import { SetStateAction, useState } from "react";
 import { toast } from "sonner";
-
 import { Input } from "@/components/ui/input";
 import { Button } from "@/components/ui/button";
 import { Combobox } from "@/components/ui/combobox";
-
-import { MedalDataDto, MedalRecordDto } from "@/types.dto";
-import { MEDAL_FORM_SUBMIT_TYPE, MEDAL_LABELS, MEDAL_TYPE } from "@/types.type";
 import { getFormActionValue, getLocalStorageData } from "@/lib/utils";
 import {
   LOCAL_STORAGE_MEDAL_LIST,
   PARIS_OLYMPICS_COUNTRIES_OPTION,
 } from "@/constants";
+
+import { MedalDataDto, MedalRecordDto } from "@/types.dto";
+import { MEDAL_FORM_SUBMIT_TYPE, MEDAL_LABELS, MEDAL_TYPE } from "@/types.type";
 
 export interface MedalFormProps {
   setMedalList: React.Dispatch<SetStateAction<MedalRecordDto[]>>;

--- a/src/containers/MedalForm.tsx
+++ b/src/containers/MedalForm.tsx
@@ -5,10 +5,9 @@ import { Input } from "@/components/ui/input";
 import { Button } from "@/components/ui/button";
 import { Combobox } from "@/components/ui/combobox";
 
-import { MEDAL_LABELS, MEDAL_TYPES } from "@/constants/medal.constant";
 import { PARIS_OLYMPICS_COUNTRIES_OPTION } from "@/constants/country.constant";
 import { MedalRecordDto } from "@/types.dto";
-import { MEDAL_FORM_SUBMIT_TYPE } from "@/types.type";
+import { MEDAL_FORM_SUBMIT_TYPE, MEDAL_LABELS, MEDAL_TYPE } from "@/types.type";
 
 export interface MedalFormProps {
   onSubmit: (data: MedalRecordDto, type: MEDAL_FORM_SUBMIT_TYPE) => void;
@@ -61,17 +60,19 @@ export default function MedalForm({ onSubmit }: MedalFormProps) {
             defaultValue="국가 선택"
           />
         </div>
-        {MEDAL_TYPES.map((type) => (
-          <div key={type} className="flex-1">
-            <p className="font-medium">{MEDAL_LABELS[type]}</p>
-            <Input
-              type="number"
-              id={type}
-              value={formData[type]}
-              onChange={handleMedalCountChange}
-            />
-          </div>
-        ))}
+        {(Object.keys(MEDAL_TYPE) as Array<keyof typeof MEDAL_TYPE>).map(
+          (type) => (
+            <div key={type} className="flex-1">
+              <p className="font-medium">{MEDAL_LABELS[MEDAL_TYPE[type]]}</p>
+              <Input
+                type="number"
+                id={type}
+                value={formData[MEDAL_TYPE[type]]}
+                onChange={handleMedalCountChange}
+              />
+            </div>
+          )
+        )}
       </div>
       <div className="flex flex-row-reverse gap-4">
         <Button

--- a/src/containers/MedalTable.tsx
+++ b/src/containers/MedalTable.tsx
@@ -1,3 +1,5 @@
+import { SetStateAction, useState } from "react";
+import { ArrowUpDown } from "lucide-react";
 import { Button } from "@/components/ui/button";
 import {
   Table,
@@ -9,8 +11,6 @@ import {
 } from "@/components/ui/table";
 
 import { MedalRecordDto } from "@/types.dto";
-import { ArrowUpDown } from "lucide-react";
-import { SetStateAction, useState } from "react";
 
 export interface MedalTableProps {
   medalList: MedalRecordDto[];

--- a/src/containers/MedalTable.tsx
+++ b/src/containers/MedalTable.tsx
@@ -12,12 +12,8 @@ import { MedalRecordDto } from "@/types.dto";
 import { ArrowUpDown } from "lucide-react";
 import { SetStateAction, useState } from "react";
 
-interface MedalRecordWithCountDto extends MedalRecordDto {
-  total: number;
-}
-
 export interface MedalTableProps {
-  medalList: MedalRecordWithCountDto[];
+  medalList: MedalRecordDto[];
   setMedalList: React.Dispatch<SetStateAction<MedalRecordDto[]>>;
 }
 
@@ -34,7 +30,7 @@ export default function MedalTable({
     setIsSortByTotal((prev) => !prev);
   }
 
-  function handleDeleteButtonClick(item: MedalRecordWithCountDto) {
+  function handleDeleteButtonClick(item: MedalRecordDto) {
     setMedalList((prev) =>
       prev.filter((medal) => medal.country !== item.country)
     );
@@ -85,19 +81,13 @@ export default function MedalTable({
   );
 }
 
-function byMedalSorting(
-  a: MedalRecordWithCountDto,
-  b: MedalRecordWithCountDto
-) {
+function byMedalSorting(a: MedalRecordDto, b: MedalRecordDto) {
   if (a.gold === b.gold && a.sliver === b.sliver) return b.bronze - a.bronze;
   if (a.gold === b.gold) return b.sliver - a.sliver;
   return b.gold - a.gold;
 }
 
-function byTotalSorting(
-  a: MedalRecordWithCountDto,
-  b: MedalRecordWithCountDto
-) {
+function byTotalSorting(a: MedalRecordDto, b: MedalRecordDto) {
   if (a.total === b.total) return byMedalSorting(a, b);
   return b.total - a.total;
 }

--- a/src/containers/MedalTable.tsx
+++ b/src/containers/MedalTable.tsx
@@ -30,10 +30,8 @@ export default function MedalTable({
     setIsSortByTotal((prev) => !prev);
   }
 
-  function handleDeleteButtonClick(item: MedalRecordDto) {
-    setMedalList((prev) =>
-      prev.filter((medal) => medal.country !== item.country)
-    );
+  function handleDeleteButtonClick(medalRecordId: string) {
+    setMedalList((prev) => prev.filter((medal) => medal.id !== medalRecordId));
   }
 
   return (
@@ -46,7 +44,7 @@ export default function MedalTable({
             <TableHead className="text-center">은메달</TableHead>
             <TableHead className="text-center">동메달</TableHead>
             <TableHead className="text-center">
-              <Button variant="ghost" onClick={() => handleTotalHeaderClick()}>
+              <Button variant="ghost" onClick={handleTotalHeaderClick}>
                 전체 합
                 <ArrowUpDown />
               </Button>
@@ -57,12 +55,14 @@ export default function MedalTable({
         <TableBody>
           {medalList.length ? (
             sortedMedalList.map((item) => (
-              <TableRow key={item.country}>
-                {Object.entries(item).map(([key, value]) => (
-                  <TableCell key={key}>{value}</TableCell>
-                ))}
+              <TableRow key={item.id}>
+                <TableCell>{item.country}</TableCell>
+                <TableCell>{item.gold}</TableCell>
+                <TableCell>{item.sliver}</TableCell>
+                <TableCell>{item.bronze}</TableCell>
+                <TableCell>{item.total}</TableCell>
                 <TableCell>
-                  <Button onClick={() => handleDeleteButtonClick(item)}>
+                  <Button onClick={() => handleDeleteButtonClick(item.id)}>
                     삭제
                   </Button>
                 </TableCell>

--- a/src/lib/utils.ts
+++ b/src/lib/utils.ts
@@ -1,6 +1,18 @@
-import { clsx, type ClassValue } from "clsx"
-import { twMerge } from "tailwind-merge"
+import { clsx, type ClassValue } from "clsx";
+import { twMerge } from "tailwind-merge";
 
 export function cn(...inputs: ClassValue[]) {
-  return twMerge(clsx(inputs))
+  return twMerge(clsx(inputs));
+}
+
+export function getLocalStorageData(key: string) {
+  return JSON.parse(localStorage.getItem(key) ?? "");
+}
+
+export function getFormActionValue(e: React.FormEvent<HTMLFormElement>) {
+  const submitter = (e.nativeEvent as SubmitEvent)
+    .submitter as HTMLButtonElement;
+  const action = submitter.formAction.split("/").at(-1);
+
+  return action;
 }

--- a/src/types.dto.ts
+++ b/src/types.dto.ts
@@ -1,7 +1,11 @@
-import { MEDAL_TYPE } from "./types.type";
-
-export type MedalRecordDto = {
+export interface MedalDataDto {
   country: string;
-} & {
-  [key in MEDAL_TYPE]: number;
-};
+  gold: number;
+  sliver: number;
+  bronze: number;
+}
+
+export interface MedalRecordDto extends MedalDataDto {
+  id: string;
+  total: number;
+}

--- a/src/types.dto.ts
+++ b/src/types.dto.ts
@@ -1,7 +1,7 @@
-import { MedalType } from "./constants/medal.constant";
+import { MEDAL_TYPE } from "./types.type";
 
 export type MedalRecordDto = {
   country: string;
 } & {
-  [key in MedalType]: number;
+  [key in MEDAL_TYPE]: number;
 };

--- a/src/types.type.ts
+++ b/src/types.type.ts
@@ -4,3 +4,16 @@ export const MEDAL_FORM_SUBMIT_TYPE = {
 } as const;
 export type MEDAL_FORM_SUBMIT_TYPE =
   (typeof MEDAL_FORM_SUBMIT_TYPE)[keyof typeof MEDAL_FORM_SUBMIT_TYPE];
+
+export const MEDAL_TYPE = {
+  GOLD: "gold",
+  SLIVER: "sliver",
+  BRONZE: "bronze",
+} as const;
+export type MEDAL_TYPE = (typeof MEDAL_TYPE)[keyof typeof MEDAL_TYPE];
+
+export const MEDAL_LABELS = {
+  [MEDAL_TYPE.GOLD]: "금메달",
+  [MEDAL_TYPE.SLIVER]: "은메달",
+  [MEDAL_TYPE.BRONZE]: "동메달",
+} as const;

--- a/src/types.type.ts
+++ b/src/types.type.ts
@@ -1,4 +1,6 @@
-export enum MedalFormSubmitType {
-  ADD = "ADD",
-  UPDATE = "UPDATE",
-}
+export const MEDAL_FORM_SUBMIT_TYPE = {
+  ADD: "ADD",
+  UPDATE: "UPDATE",
+} as const;
+export type MEDAL_FORM_SUBMIT_TYPE =
+  (typeof MEDAL_FORM_SUBMIT_TYPE)[keyof typeof MEDAL_FORM_SUBMIT_TYPE];


### PR DESCRIPTION
## 💡 관련이슈
- close #9 

## 🍀 작업 요약
- Enum을 사용했을 때 성능 상의 이슈가 있다.
  - Enum이 IIFE(즉시 실행 함수)로 컴파일되면서 Tree shaking시 사용되는지 참조할 수 없어, 사용하지 않는 Enum도 번들에 포함되는 이슈가 있음.
  - Union Type으로 변경함.
- import를 할 때 여러 단락으로 나뉘면 오히려 가독성을 해친다.
  - type을 제외한 다른 컴포넌트, 함수, 상수들은 그저 값을 가져와서 사용하는 것이기 때문에 한 묶음으로 묶고 type만 분리하였다.
- px와 tailwind의 기본 단위인 rem을 혼동해서 사용했다.
  - 기본 단위인 rem을 따르도록 수정
- handleSubmit이 꼭 App.tsx에 필요한가.
  - App.tsx에는 UI 구조와 로컬 스토리지 상태를 관리하는 상태 하나만 두도록 변경
  - handleSubmit은 자식 컴포넌트 중 MedalForm 컴포넌트로 이동
- MEDAL_TYPES 과 MEDAL_LABELS 2개로 관리되고 있다.
  - MEDAL_LABEL의 프로퍼티 키로 MEDAL_TYPE을 사용하여 해결
- return 문 안에는 최대한 깔끔하게 유지하는게 좋다.
  - 로컬 스토리지에 저장할 때 id와 total 값을 저장하게 하여, 컴포넌트로 인자를 넘겨줄 때 계산하는 부분 삭제
- 현재 속성에서 country를 사용하고 있긴 한데,,, 괜찮긴한데,,, 그래도 id가 어떨지!!! -> 아 좋습니다!! 바꾸겠습니당!!!
  - 기존의 MedalRecordDto 타입을 MedalDataDto로 수정하고 id와 totla(메달의 합계)를 추가로 담은 MedalRecordDto를 생성하여 관리

## 💬 리뷰 요구 사항
- 코드 가독성이 어떻게하면 좋아질 수 있을까...
- 지금 MedalForm.tsx 코드가 어지러운 것 같은데 어떻게 하면 깔끔하게 만들 수 있을지 고민...
- 리뷰 예상 시간 : `15분`

## 💛 미리보기
- 디자인 수정 없습니다!
