### PR TITLE
Feature/#11 medal form 컴포넌트 코드 리뷰 반영

### DIFF
--- a/src/containers/MedalForm.tsx
+++ b/src/containers/MedalForm.tsx
@@ -44,38 +44,46 @@ export default function MedalForm({ setMedalList }: MedalFormProps) {
       0
     );
 
-    if (type === MedalFormSubmitType.ADD)
-      setMedalList((prev) => [
-        ...prev,
-        { ...formData, id, total: totalMedalCount },
-      ]);
-    if (type === MedalFormSubmitType.UPDATE)
-      setMedalList((prev) => [
-        ...prev.filter((item) => item.country !== formData.country),
-        { ...formData, id, total: totalMedalCount },
-      ]);
+    switch (type) {
+      case MedalFormSubmitType.ADD:
+        setMedalList((prev) => [
+          ...prev,
+          { ...formData, id, total: totalMedalCount },
+        ]);
+        break;
+      case MedalFormSubmitType.UPDATE:
+        setMedalList((prev) => [
+          ...prev.filter((item) => item.country !== formData.country),
+          { ...formData, id, total: totalMedalCount },
+        ]);
+        break;
+      default:
+        break;
+    }
+  }
+
+  function resetFormData() {
+    setFormData(initialFormData);
   }
 
   function handleSubmit(e: React.FormEvent<HTMLFormElement>) {
     e.preventDefault();
     if (isInvalidateFormData(formData)) {
-      toast.warning("잘못된 입력 형식입니다.", {
+      return toast.warning("잘못된 입력 형식입니다.", {
         description: "국가가 선택되었고 메달의 값이 0 이상인지 확인해 주세요.",
       });
-      return;
     }
 
     const actionType = getFormActionValue<MedalFormSubmitType>(e);
     if (formSubmitLogic[actionType].isInvalidate(formData.country)) {
-      toast.warning("잘못된 입력 방식입니다.", {
+      return toast.warning("잘못된 입력 방식입니다.", {
         description: formSubmitLogic[actionType].errorMessage,
       });
-      return;
     }
 
     saveMedalList(formData, actionType);
 
-    setFormData(initialFormData);
+    resetFormData();
   }
 
   return (

--- a/src/containers/MedalForm.tsx
+++ b/src/containers/MedalForm.tsx
@@ -65,7 +65,7 @@ export default function MedalForm({ setMedalList }: MedalFormProps) {
       return;
     }
 
-    const actionType = getFormActionValue(e) as MEDAL_FORM_SUBMIT_TYPE;
+    const actionType = getFormActionValue<MEDAL_FORM_SUBMIT_TYPE>(e);
     if (formSubmitLogic[actionType].isInvalidate(formData.country)) {
       toast.warning("잘못된 입력 방식입니다.", {
         description: formSubmitLogic[actionType].errorMessage,

--- a/src/containers/MedalForm.tsx
+++ b/src/containers/MedalForm.tsx
@@ -8,9 +8,9 @@ import { PARIS_OLYMPICS_COUNTRIES_OPTION } from "@/constants";
 
 import { MedalDataDto, MedalRecordDto } from "@/types.dto";
 import {
-  MEDAL_FORM_SUBMIT_TYPE,
+  MedalFormSubmitType,
   MEDAL_LABELS,
-  MEDAL_TYPE,
+  MedalType,
   MedalTypeList,
 } from "@/types.type";
 import { formSubmitLogic, isInvalidateFormData } from "@/lib/medalForm.util";
@@ -37,19 +37,19 @@ export default function MedalForm({ setMedalList }: MedalFormProps) {
     }));
   }
 
-  function saveMedalList(formData: MedalDataDto, type: MEDAL_FORM_SUBMIT_TYPE) {
+  function saveMedalList(formData: MedalDataDto, type: MedalFormSubmitType) {
     const id = crypto.randomUUID();
     const totalMedalCount = MedalTypeList.reduce(
-      (sum, key) => sum + formData[MEDAL_TYPE[key]],
+      (sum, key) => sum + formData[MedalType[key]],
       0
     );
 
-    if (type === MEDAL_FORM_SUBMIT_TYPE.ADD)
+    if (type === MedalFormSubmitType.ADD)
       setMedalList((prev) => [
         ...prev,
         { ...formData, id, total: totalMedalCount },
       ]);
-    if (type === MEDAL_FORM_SUBMIT_TYPE.UPDATE)
+    if (type === MedalFormSubmitType.UPDATE)
       setMedalList((prev) => [
         ...prev.filter((item) => item.country !== formData.country),
         { ...formData, id, total: totalMedalCount },
@@ -65,7 +65,7 @@ export default function MedalForm({ setMedalList }: MedalFormProps) {
       return;
     }
 
-    const actionType = getFormActionValue<MEDAL_FORM_SUBMIT_TYPE>(e);
+    const actionType = getFormActionValue<MedalFormSubmitType>(e);
     if (formSubmitLogic[actionType].isInvalidate(formData.country)) {
       toast.warning("잘못된 입력 방식입니다.", {
         description: formSubmitLogic[actionType].errorMessage,
@@ -92,11 +92,11 @@ export default function MedalForm({ setMedalList }: MedalFormProps) {
         </div>
         {MedalTypeList.map((type) => (
           <div key={type} className="flex-1">
-            <p className="font-medium">{MEDAL_LABELS[MEDAL_TYPE[type]]}</p>
+            <p className="font-medium">{MEDAL_LABELS[MedalType[type]]}</p>
             <Input
               type="number"
               id={type}
-              value={formData[MEDAL_TYPE[type]]}
+              value={formData[MedalType[type]]}
               onChange={handleMedalCountChange}
             />
           </div>
@@ -106,11 +106,11 @@ export default function MedalForm({ setMedalList }: MedalFormProps) {
         <Button
           variant="outline"
           type="submit"
-          formAction={MEDAL_FORM_SUBMIT_TYPE.UPDATE}
+          formAction={MedalFormSubmitType.UPDATE}
         >
           갱신하기
         </Button>
-        <Button type="submit" formAction={MEDAL_FORM_SUBMIT_TYPE.ADD}>
+        <Button type="submit" formAction={MedalFormSubmitType.ADD}>
           추가하기
         </Button>
       </div>

--- a/src/containers/MedalForm.tsx
+++ b/src/containers/MedalForm.tsx
@@ -3,14 +3,12 @@ import { toast } from "sonner";
 import { Input } from "@/components/ui/input";
 import { Button } from "@/components/ui/button";
 import { Combobox } from "@/components/ui/combobox";
-import { getFormActionValue, getLocalStorageData } from "@/lib/utils";
-import {
-  LOCAL_STORAGE_MEDAL_LIST,
-  PARIS_OLYMPICS_COUNTRIES_OPTION,
-} from "@/constants";
+import { getFormActionValue } from "@/lib/utils";
+import { PARIS_OLYMPICS_COUNTRIES_OPTION } from "@/constants";
 
 import { MedalDataDto, MedalRecordDto } from "@/types.dto";
 import { MEDAL_FORM_SUBMIT_TYPE, MEDAL_LABELS, MEDAL_TYPE } from "@/types.type";
+import { formSubmitLogic, isInvalidateFormData } from "@/lib/medalForm.util";
 
 export interface MedalFormProps {
   setMedalList: React.Dispatch<SetStateAction<MedalRecordDto[]>>;
@@ -54,7 +52,7 @@ export default function MedalForm({ setMedalList }: MedalFormProps) {
 
   function handleSubmit(e: React.FormEvent<HTMLFormElement>) {
     e.preventDefault();
-    if (isInvalidateMedalFormData(formData)) {
+    if (isInvalidateFormData(formData)) {
       toast.warning("잘못된 입력 형식입니다.", {
         description: "국가가 선택되었고 메달의 값이 0 이상인지 확인해 주세요.",
       });
@@ -62,9 +60,9 @@ export default function MedalForm({ setMedalList }: MedalFormProps) {
     }
 
     const actionType = getFormActionValue(e) as MEDAL_FORM_SUBMIT_TYPE;
-    if (FormSubmitConfig[actionType].isInvalidate(formData.country)) {
+    if (formSubmitLogic[actionType].isInvalidate(formData.country)) {
       toast.warning("잘못된 입력 방식입니다.", {
-        description: FormSubmitConfig[actionType].errorMessage,
+        description: formSubmitLogic[actionType].errorMessage,
       });
       return;
     }
@@ -122,32 +120,3 @@ const initialFormData: MedalDataDto = {
   sliver: 0,
   bronze: 0,
 };
-
-const FormSubmitConfig: {
-  [key in MEDAL_FORM_SUBMIT_TYPE]: {
-    errorMessage: string;
-    isInvalidate: (country: string) => boolean;
-  };
-} = {
-  [MEDAL_FORM_SUBMIT_TYPE.ADD]: {
-    errorMessage: "이미 존재하는 국가입니다.",
-    isInvalidate: (country) =>
-      getLocalStorageData(LOCAL_STORAGE_MEDAL_LIST).some(
-        (item: MedalRecordDto) => item.country === country
-      ),
-  },
-  [MEDAL_FORM_SUBMIT_TYPE.UPDATE]: {
-    errorMessage: "기존에 존재하지 않은 국가입니다.",
-    isInvalidate: (country) =>
-      !getLocalStorageData(LOCAL_STORAGE_MEDAL_LIST).some(
-        (item: MedalRecordDto) => item.country === country
-      ),
-  },
-};
-
-function isInvalidateMedalFormData(formData: MedalDataDto) {
-  if (formData.country === "") return true;
-  if (formData.gold < 0 || formData.sliver < 0 || formData.bronze < 0)
-    return true;
-  return false;
-}

--- a/src/containers/MedalForm.tsx
+++ b/src/containers/MedalForm.tsx
@@ -7,7 +7,12 @@ import { getFormActionValue } from "@/lib/utils";
 import { PARIS_OLYMPICS_COUNTRIES_OPTION } from "@/constants";
 
 import { MedalDataDto, MedalRecordDto } from "@/types.dto";
-import { MEDAL_FORM_SUBMIT_TYPE, MEDAL_LABELS, MEDAL_TYPE } from "@/types.type";
+import {
+  MEDAL_FORM_SUBMIT_TYPE,
+  MEDAL_LABELS,
+  MEDAL_TYPE,
+  MedalTypeList,
+} from "@/types.type";
 import { formSubmitLogic, isInvalidateFormData } from "@/lib/medalForm.util";
 
 export interface MedalFormProps {
@@ -34,9 +39,10 @@ export default function MedalForm({ setMedalList }: MedalFormProps) {
 
   function saveMedalList(formData: MedalDataDto, type: MEDAL_FORM_SUBMIT_TYPE) {
     const id = crypto.randomUUID();
-    const totalMedalCount = (
-      Object.keys(MEDAL_TYPE) as Array<keyof typeof MEDAL_TYPE>
-    ).reduce((sum, key) => sum + formData[MEDAL_TYPE[key]], 0);
+    const totalMedalCount = MedalTypeList.reduce(
+      (sum, key) => sum + formData[MEDAL_TYPE[key]],
+      0
+    );
 
     if (type === MEDAL_FORM_SUBMIT_TYPE.ADD)
       setMedalList((prev) => [
@@ -84,19 +90,17 @@ export default function MedalForm({ setMedalList }: MedalFormProps) {
             defaultValue="국가 선택"
           />
         </div>
-        {(Object.keys(MEDAL_TYPE) as Array<keyof typeof MEDAL_TYPE>).map(
-          (type) => (
-            <div key={type} className="flex-1">
-              <p className="font-medium">{MEDAL_LABELS[MEDAL_TYPE[type]]}</p>
-              <Input
-                type="number"
-                id={type}
-                value={formData[MEDAL_TYPE[type]]}
-                onChange={handleMedalCountChange}
-              />
-            </div>
-          )
-        )}
+        {MedalTypeList.map((type) => (
+          <div key={type} className="flex-1">
+            <p className="font-medium">{MEDAL_LABELS[MEDAL_TYPE[type]]}</p>
+            <Input
+              type="number"
+              id={type}
+              value={formData[MEDAL_TYPE[type]]}
+              onChange={handleMedalCountChange}
+            />
+          </div>
+        ))}
       </div>
       <div className="flex flex-row-reverse gap-4">
         <Button

--- a/src/lib/medalForm.util.ts
+++ b/src/lib/medalForm.util.ts
@@ -1,22 +1,22 @@
 import { LOCAL_STORAGE_MEDAL_LIST } from "@/constants";
 import { MedalDataDto, MedalRecordDto } from "@/types.dto";
-import { MEDAL_FORM_SUBMIT_TYPE } from "@/types.type";
+import { MedalFormSubmitType } from "@/types.type";
 import { getLocalStorageData } from "./utils";
 
 export const formSubmitLogic: {
-  [key in MEDAL_FORM_SUBMIT_TYPE]: {
+  [key in MedalFormSubmitType]: {
     errorMessage: string;
     isInvalidate: (country: string) => boolean;
   };
 } = {
-  [MEDAL_FORM_SUBMIT_TYPE.ADD]: {
+  [MedalFormSubmitType.ADD]: {
     errorMessage: "이미 존재하는 국가입니다.",
     isInvalidate: (country) =>
       getLocalStorageData(LOCAL_STORAGE_MEDAL_LIST).some(
         (item: MedalRecordDto) => item.country === country
       ),
   },
-  [MEDAL_FORM_SUBMIT_TYPE.UPDATE]: {
+  [MedalFormSubmitType.UPDATE]: {
     errorMessage: "기존에 존재하지 않은 국가입니다.",
     isInvalidate: (country) =>
       !getLocalStorageData(LOCAL_STORAGE_MEDAL_LIST).some(

--- a/src/lib/medalForm.util.ts
+++ b/src/lib/medalForm.util.ts
@@ -1,0 +1,33 @@
+import { LOCAL_STORAGE_MEDAL_LIST } from "@/constants";
+import { MedalDataDto, MedalRecordDto } from "@/types.dto";
+import { MEDAL_FORM_SUBMIT_TYPE } from "@/types.type";
+import { getLocalStorageData } from "./utils";
+
+export const formSubmitLogic: {
+  [key in MEDAL_FORM_SUBMIT_TYPE]: {
+    errorMessage: string;
+    isInvalidate: (country: string) => boolean;
+  };
+} = {
+  [MEDAL_FORM_SUBMIT_TYPE.ADD]: {
+    errorMessage: "이미 존재하는 국가입니다.",
+    isInvalidate: (country) =>
+      getLocalStorageData(LOCAL_STORAGE_MEDAL_LIST).some(
+        (item: MedalRecordDto) => item.country === country
+      ),
+  },
+  [MEDAL_FORM_SUBMIT_TYPE.UPDATE]: {
+    errorMessage: "기존에 존재하지 않은 국가입니다.",
+    isInvalidate: (country) =>
+      !getLocalStorageData(LOCAL_STORAGE_MEDAL_LIST).some(
+        (item: MedalRecordDto) => item.country === country
+      ),
+  },
+};
+
+export function isInvalidateFormData(formData: MedalDataDto) {
+  if (formData.country === "") return true;
+  if (formData.gold < 0 || formData.sliver < 0 || formData.bronze < 0)
+    return true;
+  return false;
+}

--- a/src/lib/utils.ts
+++ b/src/lib/utils.ts
@@ -9,10 +9,10 @@ export function getLocalStorageData(key: string) {
   return JSON.parse(localStorage.getItem(key) ?? "");
 }
 
-export function getFormActionValue(e: React.FormEvent<HTMLFormElement>) {
+export function getFormActionValue<T>(e: React.FormEvent<HTMLFormElement>) {
   const submitter = (e.nativeEvent as SubmitEvent)
     .submitter as HTMLButtonElement;
   const action = submitter.formAction.split("/").at(-1);
 
-  return action;
+  return action as T;
 }

--- a/src/types.type.ts
+++ b/src/types.type.ts
@@ -11,6 +11,9 @@ export const MEDAL_TYPE = {
   BRONZE: "bronze",
 } as const;
 export type MEDAL_TYPE = (typeof MEDAL_TYPE)[keyof typeof MEDAL_TYPE];
+export const MedalTypeList = Object.keys(MEDAL_TYPE) as Array<
+  keyof typeof MEDAL_TYPE
+>;
 
 export const MEDAL_LABELS = {
   [MEDAL_TYPE.GOLD]: "금메달",

--- a/src/types.type.ts
+++ b/src/types.type.ts
@@ -1,22 +1,22 @@
-export const MEDAL_FORM_SUBMIT_TYPE = {
+export const MedalFormSubmitType = {
   ADD: "ADD",
   UPDATE: "UPDATE",
 } as const;
-export type MEDAL_FORM_SUBMIT_TYPE =
-  (typeof MEDAL_FORM_SUBMIT_TYPE)[keyof typeof MEDAL_FORM_SUBMIT_TYPE];
+export type MedalFormSubmitType =
+  (typeof MedalFormSubmitType)[keyof typeof MedalFormSubmitType];
 
-export const MEDAL_TYPE = {
+export const MedalType = {
   GOLD: "gold",
   SLIVER: "sliver",
   BRONZE: "bronze",
 } as const;
-export type MEDAL_TYPE = (typeof MEDAL_TYPE)[keyof typeof MEDAL_TYPE];
-export const MedalTypeList = Object.keys(MEDAL_TYPE) as Array<
-  keyof typeof MEDAL_TYPE
+export type MedalType = (typeof MedalType)[keyof typeof MedalType];
+export const MedalTypeList = Object.keys(MedalType) as Array<
+  keyof typeof MedalType
 >;
 
 export const MEDAL_LABELS = {
-  [MEDAL_TYPE.GOLD]: "금메달",
-  [MEDAL_TYPE.SLIVER]: "은메달",
-  [MEDAL_TYPE.BRONZE]: "동메달",
+  [MedalType.GOLD]: "금메달",
+  [MedalType.SLIVER]: "은메달",
+  [MedalType.BRONZE]: "동메달",
 } as const;


### PR DESCRIPTION
## 💡 관련이슈
- close #11 

## 🍀 작업 요약
- MedalForm 하단의 FormSubmitConfig 및 isInvalidateMedalFormData는 별도의 서비스 로직으로 분리하기
- type은 파스칼 케이스로 변경
- enum과 같은 type은 switch 문으로 변경
- type 단언 줄이기 함수의 반환 값의 단언은 generic으로 타입을 넣어주던가 내부적으로 단언을 해서 나오도록 변경
- setFormData(initialFormData) 이런 로직은 resetForm 같은 함수로 변경

## 💬 리뷰 요구 사항
- 리뷰 예상 시간 : `15분`

## 💛 미리보기
- 디자인 수정사항 없습니다!
